### PR TITLE
Fix execution error on Mac Anki 2.1.54

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-# Anki-Translator (Forked and updated to Anki 2.1)
-######v1.1
+# Anki-Translator (Forked and updated to Anki 2.1.54+)
+
+Works on config:
+Anki 2.1.54 (b6a7760c) Python 3.9.7 Qt 6.3.1 PyQt 6.3.1
+Platform: Mac 12.5.1
+Flags: frz=True ao=True sv=2
+
+
 Anki-Translator is a Add-On for the flashcard program [Anki](http://ankisrs.net/).
 
 This Add-On translates vocabularies for you. So if you want to add a new flashcard to your deck you can open this Add-On 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,5 @@ of the variables in the file '__init__.py'. You can find the file in the Add-Ons
 (See the highlighted lines.)
 
 ## Installation
-This Add-On is also posted on the [Anki Add-Ons Website]. You can use the Add-On Installer, which is integrated into Anki, to install the Translator. 
 
-
-Or you can download this project as a zip and uncompress the folder into your Anki Addon folder (../addons21/Anki-Translator-master).
+Download this project as a zip and uncompress the folder into your Anki Addon folder (../addons21/Anki-Translator-master).

--- a/TranslatorAddon/TranslatorDialog.py
+++ b/TranslatorAddon/TranslatorDialog.py
@@ -104,8 +104,8 @@ class TranslatorDialog(QDialog):
         self.tableTranslations.horizontalHeader().resizeSection(1, (self.tableTranslations.size().width() - self.col0Width) / 2)
         self.tableTranslations.verticalHeader().hide()
         policy = QSizePolicy()
-        policy.setHorizontalPolicy(policy.Expanding)
-        policy.setVerticalPolicy(policy.Expanding)
+        policy.setHorizontalPolicy(policy.Policy.Expanding)
+        policy.setVerticalPolicy(policy.Policy.Expanding)
         policy.setVerticalStretch(1)
         self.tableTranslations.setSizePolicy(policy)
 


### PR DESCRIPTION
Caught exception:
Traceback (most recent call last):
  File "aqt.webview", line 42, in cmd
  File "aqt.webview", line 149, in _onCmd
  File "aqt.webview", line 624, in _onBridgeCmd
  File "aqt.editor", line 467, in onBridgeCmd
  File "/Users/argon/Library/Application Support/Anki2/addons21/702944768/TranslatorAddon/__init__.py", line 16, in onGetTranslation
    dialog = td.TranslatorDialog(editor.note.fields[0], defaultSourceLanguage, defaultTargetLanguage, defaultLoadGrammarInfos)
  File "/Users/argon/Library/Application Support/Anki2/addons21/702944768/TranslatorAddon/TranslatorDialog.py", line 25, in __init__
    self.setupUi()
  File "/Users/argon/Library/Application Support/Anki2/addons21/702944768/TranslatorAddon/TranslatorDialog.py", line 38, in setupUi
    self.createTranslContent()
  File "/Users/argon/Library/Application Support/Anki2/addons21/702944768/TranslatorAddon/TranslatorDialog.py", line 107, in createTranslContent
    policy.setHorizontalPolicy(policy.Expanding)
AttributeError: 'QtClassProxy' object has no attribute 'Expanding'